### PR TITLE
refactor: add a cache to memorise the data using useRef hook

### DIFF
--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -1,19 +1,25 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 import axios from 'axios'
 
+// todo apply useRef for data catch
 /** Custom hook that fetches the data (like reviews and animals) from server
  *  If the withToken is true, a token is added in the headers
  */
 const useFetch = (url, withToken = false) => {
+  let cancelRequest = false
   const [data, setData] = useState([])
   const [isLoaded, setIsLoaded] = useState(false)
+
+  // Memoizing Data With useRef
+  const cache = useRef({})
+
   // When url or withToken changes, triggle fetchData function to update data
   useEffect(() => {
-    // Fetch the data from the server
     // Move the function into the effect as it is only ever used in this local effect
     const fetchData = async () => {
       setIsLoaded(false)
+      if (!url) return
       try {
         let config
         if (withToken) {
@@ -24,13 +30,27 @@ const useFetch = (url, withToken = false) => {
             },
           }
         }
-        const response = await axios.get(url, config)
-        if (response.status === 200) {
-          setData(response.data)
+        if (cache.current[url]) {
+          const data = cache.current[url]
+          setData(data)
           setIsLoaded(true)
+        } else {
+          const response = await axios.get(url, config)
+          if (response.status === 200) {
+            const data = response.data
+            cache.current[url] = data
+            if (cancelRequest) return
+            setData(data)
+            setIsLoaded(true)
+          }
         }
       } catch (err) {
+        if (cancelRequest) return
         console.log(err.message)
+      }
+
+      return function cleanup() {
+        cancelRequest = true
       }
     }
     fetchData()


### PR DESCRIPTION
Used useRef hook to memorise the data previously fetched from the server, to reduce the number of fetching data. Added checking and clean up function in useEffect to deal with the component unmounted during the fetching issue.